### PR TITLE
Include file paths in tap runner output

### DIFF
--- a/lib/test/unit/runner/tap.rb
+++ b/lib/test/unit/runner/tap.rb
@@ -1,5 +1,6 @@
 require 'test-unit'
 require 'test/unit/runner/tap-version'
+require 'test/unit/ui/tap/ext/base_testrunner'
 
 module Test
   module Unit

--- a/lib/test/unit/ui/tap/ext/base_testrunner.rb
+++ b/lib/test/unit/ui/tap/ext/base_testrunner.rb
@@ -1,0 +1,62 @@
+require 'test/unit/ui/tap/base_testrunner'
+
+module Test
+  module Unit
+    module UI
+      module Tap
+        class BaseTestRunner < Test::Unit::UI::TestRunner
+
+          def tapout_pass_with_source_location(test)
+            doc = tapout_pass_without_source_location(test)
+            if(doc && doc['type'] == 'test')
+              file, _ = test.class.instance_method(clean_label(test.name).to_sym).source_location
+              doc['file'] = file.sub(Dir.pwd+'/', '')
+            end
+            doc
+          end
+
+          def tapout_todo_with_source_location(fault)
+            doc = tapout_todo(fault)
+            doc['file'] = extract_source_location
+            doc
+          end
+
+          def tapout_omit_with_source_location(fault)
+            doc = tapout_omit_without_source_location(fault)
+            doc['file'] = extract_source_location(fault) if doc
+            doc
+          end
+
+          def tapout_fail_with_source_location(fault)
+            doc = tapout_fail_without_source_location(fault)
+            doc['file'] = extract_source_location(fault) if doc
+            doc
+          end
+
+          def tapout_error_with_source_location(fault)
+            doc =  tapout_error_without_source_location(fault)
+            doc['file'] = extract_source_location(fault) if doc
+            doc
+          end
+
+          alias_method :tapout_pass_without_source_location, :tapout_pass
+          alias_method :tapout_pass, :tapout_pass_with_source_location
+          alias_method :tapout_omit_without_source_location, :tapout_omit
+          alias_method :tapout_omit, :tapout_omit_with_source_location
+          alias_method :tapout_fail_without_source_location, :tapout_fail
+          alias_method :tapout_fail, :tapout_fail_with_source_location
+          alias_method :tapout_error_without_source_location, :tapout_error
+          alias_method :tapout_error, :tapout_error_with_source_location
+          alias_method :tapout_todo_without_source_location, :tapout_todo
+          alias_method :tapout_todo, :tapout_todo_with_source_location
+
+          private
+            def extract_source_location(fault)
+              file, _ = location(fault.location)
+              file.sub(Dir.pwd+'/', '')
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/test/unit/ui/tap/ext/base_testrunner.rb
+++ b/lib/test/unit/ui/tap/ext/base_testrunner.rb
@@ -16,8 +16,8 @@ module Test
           end
 
           def tapout_todo_with_source_location(fault)
-            doc = tapout_todo(fault)
-            doc['file'] = extract_source_location
+            doc = tapout_todo_without_source_location(fault)
+            doc['file'] = extract_source_location(fault)
             doc
           end
 

--- a/test/fixtures/test_example.rb
+++ b/test/fixtures/test_example.rb
@@ -19,6 +19,11 @@ class ExampleTestCase < Test::Unit::TestCase
     pend
     assert_equal(3, 1 + 2)
   end
+
+  def test_omitted
+    omit
+    assert_equal(1, 1 + 0)
+  end
 end
 
 

--- a/test/fixtures/test_example.rb
+++ b/test/fixtures/test_example.rb
@@ -14,6 +14,11 @@ class ExampleTestCase < Test::Unit::TestCase
     sleep 1
     assert_equal('1', '1')
   end
+
+  def test_todo
+    pend
+    assert_equal(3, 1 + 2)
+  end
 end
 
 

--- a/test/test_tapy.rb
+++ b/test/test_tapy.rb
@@ -45,7 +45,7 @@ class TapYTest < Test::Unit::TestCase
     file = "test/fixtures/test_example.rb"
     assert_equal "Test::Unit::Failure",    @failing_test['exception']['class']
     assert_equal file,                     @failing_test['exception']['file']
-    assert_equal 12,                       @failing_test['exception']['line']
+    assert_equal 10,                       @failing_test['exception']['line']
     assert_equal "assert_equal('1', '2')", @failing_test['exception']['source']
   end
 
@@ -64,7 +64,7 @@ class TapYTest < Test::Unit::TestCase
     file = "test/fixtures/test_example.rb"
     assert_equal 'Test::Unit::Error', @erring_test['exception']['class']
     assert_equal file,                @erring_test['exception']['file']
-    assert_equal 8,                   @erring_test['exception']['line']
+    assert_equal 6,                   @erring_test['exception']['line']
     assert_equal 'raise',             @erring_test['exception']['source']
   end
 

--- a/test/test_tapy.rb
+++ b/test/test_tapy.rb
@@ -15,15 +15,16 @@ class TapYTest < Test::Unit::TestCase
     @failing_test = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'fail' }
     @erring_test  = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'error' }
     @todo_test  = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'todo' }
+    @omitted_test  = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'skip' }
   end
 
   def test_sections_count
-    assert_equal 7, @stream.size
+    assert_equal 8, @stream.size
   end
 
   def test_first_document_should_be_suite
     assert_equal 'suite', @stream.first['type']
-    assert_equal 4,       @stream.first['count']
+    assert_equal 5,       @stream.first['count']
   end
 
   def test_second_document_should_be_case
@@ -48,6 +49,14 @@ class TapYTest < Test::Unit::TestCase
     assert_equal 'Test::Unit::Pending',           @todo_test['exception']['class']
     assert_equal 'pended.',                       @todo_test['exception']['message']
     assert_equal 'pend',                          @todo_test['exception']['source']
+  end
+
+  def test_omit_should_have_correct_label_and_exception
+    assert_equal "test_omitted",                  @omitted_test['label']
+    assert_equal "test/fixtures/test_example.rb", @omitted_test['file']
+    assert_equal 'Test::Unit::Omission',          @omitted_test['exception']['class']
+    assert_equal 'omitted.',                      @omitted_test['exception']['message']
+    assert_equal 'omit',                          @omitted_test['exception']['source']
   end
 
   def test_failing_should_hash_correct_exception
@@ -88,11 +97,11 @@ class TapYTest < Test::Unit::TestCase
   end
 
   def test_last_should_have_prpoer_counts
-    assert_equal 4, @stream.last['counts']['total']
+    assert_equal 5, @stream.last['counts']['total']
     assert_equal 1, @stream.last['counts']['error']
     assert_equal 1, @stream.last['counts']['fail']
     assert_equal 1, @stream.last['counts']['pass']
-    assert_equal 0, @stream.last['counts']['omit']
+    assert_equal 1, @stream.last['counts']['omit']
     assert_equal 1, @stream.last['counts']['todo']
   end
 

--- a/test/test_tapy.rb
+++ b/test/test_tapy.rb
@@ -14,15 +14,16 @@ class TapYTest < Test::Unit::TestCase
     @passing_test = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'pass' }
     @failing_test = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'fail' }
     @erring_test  = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'error' }
+    @todo_test  = @stream.find{ |d| d['type'] == 'test' && d['status'] == 'todo' }
   end
 
-  def test_there_should_be_six_sections
-    assert_equal 6, @stream.size
+  def test_sections_count
+    assert_equal 7, @stream.size
   end
 
   def test_first_document_should_be_suite
     assert_equal 'suite', @stream.first['type']
-    assert_equal 3,       @stream.first['count']
+    assert_equal 4,       @stream.first['count']
   end
 
   def test_second_document_should_be_case
@@ -39,6 +40,14 @@ class TapYTest < Test::Unit::TestCase
   def test_failing_should_have_correct_label
     assert_equal "test_failing", @failing_test['label']
     assert_equal "test/fixtures/test_example.rb", @failing_test['file']
+  end
+
+  def test_todo_should_have_correct_label_and_exception
+    assert_equal "test_todo",                     @todo_test['label']
+    assert_equal "test/fixtures/test_example.rb", @todo_test['file']
+    assert_equal 'Test::Unit::Pending',           @todo_test['exception']['class']
+    assert_equal 'pended.',                       @todo_test['exception']['message']
+    assert_equal 'pend',                          @todo_test['exception']['source']
   end
 
   def test_failing_should_hash_correct_exception
@@ -79,12 +88,12 @@ class TapYTest < Test::Unit::TestCase
   end
 
   def test_last_should_have_prpoer_counts
-    assert_equal 3, @stream.last['counts']['total']
+    assert_equal 4, @stream.last['counts']['total']
     assert_equal 1, @stream.last['counts']['error']
     assert_equal 1, @stream.last['counts']['fail']
     assert_equal 1, @stream.last['counts']['pass']
     assert_equal 0, @stream.last['counts']['omit']
-    assert_equal 0, @stream.last['counts']['todo']
+    assert_equal 1, @stream.last['counts']['todo']
   end
 
 private

--- a/test/test_tapy.rb
+++ b/test/test_tapy.rb
@@ -33,10 +33,12 @@ class TapYTest < Test::Unit::TestCase
 
   def test_passing_should_have_correct_label
     assert_equal 'test_passing', @passing_test['label']
+    assert_equal 'test/fixtures/test_example.rb', @passing_test['file']
   end
 
   def test_failing_should_have_correct_label
     assert_equal "test_failing", @failing_test['label']
+    assert_equal "test/fixtures/test_example.rb", @failing_test['file']
   end
 
   def test_failing_should_hash_correct_exception
@@ -55,6 +57,7 @@ class TapYTest < Test::Unit::TestCase
 
   def test_erring_should_have_correct_label
     assert_equal 'test_error', @erring_test['label']
+    assert_equal 'test/fixtures/test_example.rb', @erring_test['file']
   end
 
   def test_erring_should_have_correct_exception


### PR DESCRIPTION
This PR changes the test-unit-runner-tap to include source file location for each tests. This will be useful in calculating duration taken by each test file.

This is done by extending listener methods in the BaseTestRunner class. This makes it easy to be updated with the parent branch.

JSON output: https://gist.github.com/snehaso/6aedfdd18d91cb1486da
